### PR TITLE
Create gh-26da-penguin-zone.json

### DIFF
--- a/data/patches/gh-26da-penguin-zone.json
+++ b/data/patches/gh-26da-penguin-zone.json
@@ -1,0 +1,43 @@
+{
+	"id": -1,
+	"name": "Penguin Zone",
+	"description": "Penguin Zone is a Club Penguin Private Server.\n\nA Club Penguin Private Server is a Club Penguin Server hosted by the community due to the unfortunate closing of Club Penguin in March 2017.",
+	"links": {
+		"website": [
+			"https://penguinzone.ca/"
+		],
+		"discord": [
+			"Q6CvqephtT"
+		]
+	},
+	"path": {
+		"189": [
+			[
+				74,
+				-584
+			],
+			[
+				74,
+				-557
+			],
+			[
+				100,
+				-557
+			],
+			[
+				100,
+				-584
+			],
+			[
+				74,
+				-584
+			]
+		]
+	},
+	"center": {
+		"189": [
+			87,
+			-570
+		]
+	}
+}


### PR DESCRIPTION
Penguin Zone - A Club Penguin Private Server. (A server hosted by fans of Club Penguin mostly following the closing of Club Penguin in March 2017.)