### PR TITLE
Create gh-3607-vwp-virtual-witch-phenomenon.json

### DIFF
--- a/data/patches/gh-3607-vwp-virtual-witch-phenomenon.json
+++ b/data/patches/gh-3607-vwp-virtual-witch-phenomenon.json
@@ -1,0 +1,44 @@
+{
+	"id": -1,
+	"name": "V.W.P (Virtual Witch Phenomenon)",
+	"description": "V.W.P, short for Virtual Witch Phenomenon, is a supernatural-themed virtual singer group. The group is compromised of members KAF, RIM, Harusaruhi, Isekaijoucho and koko - all performers under KAMITSUBAKI STUDIO.\n\nIn this artwork, Harusaruhi is at the top left, koko is at the top right, RIM is at the bottom left, Isekaijoucho is at the bottom, and KAF is at the bottom right.\n\nThis artwork found its way onto the canvas through the collective effort of the Kamitsubaki English community in collaboration with r/place VTubers.",
+	"links": {
+		"website": [
+			"https://www.youtube.com/@VWPVirtualWitchPhenomenon",
+			"https://kamitsubaki.fandom.com/wiki/V.W.P"
+		],
+		"subreddit": [
+			"Kamitsubaki_Fans",
+			"VirtualYoutubers"
+		],
+		"discord": [
+			"NwCy89U"
+		]
+	},
+	"path": {
+		"175-259": [
+			[
+				-159,
+				-806
+			],
+			[
+				-113,
+				-806
+			],
+			[
+				-113,
+				-776
+			],
+			[
+				-159,
+				-776
+			]
+		]
+	},
+	"center": {
+		"175-259": [
+			-136,
+			-791
+		]
+	}
+}


### PR DESCRIPTION
# Adds V.W.P (Virtual Witch Phenomenon)

> V.W.P, short for Virtual Witch Phenomenon, is a supernatural-themed virtual singer group. The group is compromised of members KAF, RIM, Harusaruhi, Isekaijoucho and koko - all performers under KAMITSUBAKI STUDIO.\n\nIn this artwork, Harusaruhi is at the top left, koko is at the top right, RIM is at the bottom left, Isekaijoucho is at the bottom, and KAF is at the bottom right.\n\nThis artwork found its way onto the canvas through the collective effort of the Kamitsubaki English community in collaboration with r/place VTubers.