### PR TITLE
Filter-first approach on atlas data

### DIFF
--- a/web/_js/config.js
+++ b/web/_js/config.js
@@ -327,7 +327,6 @@ window.defaultVariation = defaultVariation
 
 let defaultPeriod = variationsConfig[defaultVariation].default
 window.defaultPeriod = defaultPeriod
-console.log(window.defaultPeriod);
 
 const useNumericalId = true
 window.useNumericalId = useNumericalId

--- a/web/_js/main/draw.js
+++ b/web/_js/main/draw.js
@@ -386,8 +386,6 @@ function initDraw() {
 		}
 		githubPostButton.href = githubPostUrl
 
-		console.log(githubPostUrl)
-
 		exportModal.show()
 	}
 

--- a/web/_js/main/draw.js
+++ b/web/_js/main/draw.js
@@ -390,7 +390,7 @@ function initDraw() {
 	}
 
 	function preview() {
-		let infoElement = createInfoBlock(generateExportObject(), 1)
+		let infoElement = createInfoBlock(generateExportObject(), 2)
 		objectsContainer.replaceChildren()
 		objectsContainer.appendChild(infoElement)
 		closeObjectsListButton.classList.remove("d-none")
@@ -788,7 +788,7 @@ function initDraw() {
 
 	} else {
 		document.getElementById("offcanvasDrawLabel").textContent = "New Entry"
-		pathWithPeriods.push([formatPeriod(currentPeriod, currentPeriod, currentVariation), []])
+		pathWithPeriods.push([formatPeriod(currentPeriod, null, currentVariation), []])
 
 		// Builds multi-input list
 		addWebsiteFields("", 0, [0])
@@ -814,14 +814,14 @@ function initDraw() {
 	})
 
 	periodsAdd.addEventListener('click', () => {
-		pathWithPeriods.push([formatPeriod(currentPeriod, currentPeriod, currentVariation), []])
+		pathWithPeriods.push([formatPeriod(currentPeriod, null, currentVariation), []])
 		initPeriodGroups()
 	})
 
 	drawBackButton.href = "./" + formatHash(entry?.id)
 
 	document.addEventListener('timeupdate', event => {
-		drawBackButton.href = "./" + formatHash(entry?.id, event.detail.period, event.detail.period, event.detail.variation)
+		drawBackButton.href = "./" + formatHash(entry?.id, event.detail.period, event.detail.variation)
 	})
 
 }

--- a/web/_js/main/draw.js
+++ b/web/_js/main/draw.js
@@ -112,7 +112,7 @@ function initDraw() {
 	wrapper.classList.remove('listHidden')
 	bsOffcanvasDraw.show()
 
-	window.render = render
+	window.renderHighlight = renderHighlight
 	window.renderBackground = renderBackground
 	window.updateHovering = updateHovering
 
@@ -126,12 +126,12 @@ function initDraw() {
 
 	let highlightUncharted = highlightUnchartedEl.checked
 
-	renderBackground(atlas)
+	renderBackground(atlasDisplay)
 	applyView()
 
 	container.style.cursor = "crosshair"
 
-	render(path)
+	renderHighlight(path)
 
 	container.addEventListener("mousedown", e => {
 		lastPos = [
@@ -169,7 +169,7 @@ function initDraw() {
 			const coords = getCanvasCoords(e.clientX, e.clientY)
 
 			path.push(coords)
-			render(path)
+			renderHighlight(path)
 
 			undoHistory = []
 			redoButton.disabled = true
@@ -186,13 +186,13 @@ function initDraw() {
 	container.addEventListener("mousemove", e => {
 		if (!dragging && drawing && path.length > 0) {
 			const coords = getCanvasCoords(e.clientX, e.clientY)
-			render([...path, coords])
+			renderHighlight([...path, coords])
 		}
 	})
 
 	container.addEventListener("mouseout", function () {
 		if (!dragging && drawing && path.length > 0) {
-			render(path)
+			renderHighlight(path)
 		}
 	})
 
@@ -229,19 +229,19 @@ function initDraw() {
 	undoButton.addEventListener("click", e => {
 		undo()
 		const coords = getCanvasCoords(e.clientX, e.clientY)
-		render([...path, coords])
+		renderHighlight([...path, coords])
 	})
 
 	redoButton.addEventListener("click", e => {
 		redo()
 		const coords = getCanvasCoords(e.clientX, e.clientY)
-		render([...path, coords])
+		renderHighlight([...path, coords])
 	})
 
 	resetButton.addEventListener("click", e => {
 		reset()
 		const coords = getCanvasCoords(e.clientX, e.clientY)
-		render([...path, coords])
+		renderHighlight([...path, coords])
 	})
 
 	resetButton.addEventListener("blur", function () {
@@ -270,7 +270,7 @@ function initDraw() {
 
 	highlightUnchartedEl.addEventListener("click", function () {
 		highlightUncharted = this.checked
-		render(path)
+		renderHighlight(path)
 	})
 
 	function generateExportObject() {
@@ -392,7 +392,7 @@ function initDraw() {
 	}
 
 	function preview() {
-		let infoElement = createInfoBlock(generateExportObject(), true)
+		let infoElement = createInfoBlock(generateExportObject(), 1)
 		objectsContainer.replaceChildren()
 		objectsContainer.appendChild(infoElement)
 		closeObjectsListButton.classList.remove("d-none")
@@ -484,17 +484,17 @@ function initDraw() {
 		closeObjectsListButton.classList.add("d-none")
 	}
 
-	function renderBackground() {
+	function renderBackground(atlas) {
 
 		backgroundContext.clearRect(0, 0, highlightCanvas.width, highlightCanvas.height)
 
 		backgroundContext.fillStyle = "rgba(0, 0, 0, 1)"
-		//backgroundContext.fillRect(0, 0, canvas.width, canvas.height)
+		//backgroundContext.fillRect(0, 0, canvas.width, renderBackgroundcanvas.height)
 
-		for (let i = 0; i < atlas.length; i++) {
+		for (const entry of Object.values(atlas)) {
 
-			const path = atlas[i].path
-
+			const path = entry.path
+	
 			backgroundContext.beginPath()
 
 			if (path[0]) {
@@ -511,7 +511,7 @@ function initDraw() {
 		}
 	}
 
-	function render(path) {
+	function renderHighlight(path) {
 
 		if (!Array.isArray(path)) return
 
@@ -556,8 +556,7 @@ function initDraw() {
 
 	const getEntry = id => {
 		if (!id) return
-		const entries = atlasAll.filter(entry => entry.id.toString() === id.toString())
-		if (entries.length === 1) return entries[0]
+		return atlasAll[id]
 	}
 
 	function addFieldButton(inputButton, inputGroup, array, index, name) {
@@ -1225,7 +1224,7 @@ function updatePeriodGroups() {
 function updatePath(newPath, newUndoHistory) {
 	path = newPath || path
 	if (path.length > 3) center = calculateCenter(path)
-	render(path)
+	renderHighlight(path)
 	undoButton.disabled = path.length === 0; // Maybe make it undo the cancel action in the future
 	undoHistory = newUndoHistory || []
 	redoButton.disabled = (!undoHistory.length)

--- a/web/_js/main/infoblock.js
+++ b/web/_js/main/infoblock.js
@@ -49,11 +49,6 @@ function createInfoBlock(entry, mode = 0) {
 		const [nearestPeriod, nearestVariation, nearestKey] = getNearestPeriod(entry, currentPeriod, currentVariation)
 		const hash = formatHash(entry.id, nearestPeriod, nearestPeriod, nearestVariation, false, false, false)
 		linkElement.href = hash
-		linkElement.addEventListener('click', e => {
-			e.preventDefault()
-			location.hash = hash
-			// window.dispatchEvent(new HashChangeEvent("hashchange"))
-		})
 	
 	} else {
 		const hash = formatHash(entry.id, null, null, null, false, false, false)

--- a/web/_js/main/infoblock.js
+++ b/web/_js/main/infoblock.js
@@ -32,8 +32,8 @@ function createInfoListItem(name, value) {
 }
 
 // mode 0 = normal
-// mode 1 = preview
-// mode 2 = entry list but none on atlas
+// mode 1 = entry list but none on atlas
+// mode 2 = preview
 function createInfoBlock(entry, mode = 0) {
 	const element = document.createElement("div")
 	element.className = "card mb-2 overflow-hidden shadow"
@@ -43,22 +43,21 @@ function createInfoBlock(entry, mode = 0) {
 
 	const linkElement = document.createElement("a")
 	linkElement.className = "text-decoration-none d-flex justify-content-between text-body"
-	if (mode === 1) linkElement.href = "#"
-	
-	else if (mode === 2) {
-		const [nearestPeriod, nearestVariation, nearestKey] = getNearestPeriod(entry, currentPeriod, currentVariation)
-		const hash = formatHash(entry.id, nearestPeriod, nearestPeriod, nearestVariation, false, false, false)
+
+	const [nearestPeriod, nearestVariation] = getNearestPeriod(entry, currentPeriod, currentVariation)
+
+	if (mode === 2)  {
+		linkElement.href = "#" 
+	} else { 
+		const hash = formatHash(entry.id, nearestPeriod, nearestVariation, false, false, false)
 		linkElement.href = hash
-	
-	} else {
-		const hash = formatHash(entry.id, null, null, null, false, false, false)
-		linkElement.href = hash
-		linkElement.addEventListener('click', e => {
+		if (mode === 0) linkElement.addEventListener('click', e => {
 			e.preventDefault()
 			location.hash = hash
 			window.dispatchEvent(new HashChangeEvent("hashchange"))
 		})
 	}
+
 	const linkNameElement = document.createElement("span")
 	linkNameElement.className = "flex-grow-1 text-break"
 	linkNameElement.textContent = entry.name
@@ -180,11 +179,11 @@ function createInfoBlock(entry, mode = 0) {
 	element.appendChild(idElementContainer)
 
 	// Adds edit button only if element is not deleted
-	if (mode === 0 && (!entry.diff || entry.diff !== "delete")) {
+	if (mode < 2 && (!entry.diff || entry.diff !== "delete")) {
 		const editElement = document.createElement("a")
 		editElement.innerHTML = '<i class="bi bi-pencil-fill" aria-hidden="true"></i> Edit'
 		editElement.className = "btn btn-sm btn-outline-primary"
-		editElement.href = "./?mode=draw&id=" + entry.id + formatHash(false, null, null, null, false, false, false)
+		editElement.href = "./?mode=draw&id=" + entry.id + formatHash(false, nearestPeriod, nearestVariation, false, false, false)
 		editElement.title = "Edit " + entry.name
 		idElementContainer.appendChild(editElement)
 	}

--- a/web/_js/main/infoblock.js
+++ b/web/_js/main/infoblock.js
@@ -44,16 +44,17 @@ function createInfoBlock(entry, mode = 0) {
 	const linkElement = document.createElement("a")
 	linkElement.className = "text-decoration-none d-flex justify-content-between text-body"
 	if (mode === 1) linkElement.href = "#"
+	
 	else if (mode === 2) {
-		const [nearestPeriod, nearestVariation] = getNearestPeriod(entry, currentPeriod, currentVariation)
+		const [nearestPeriod, nearestVariation, nearestKey] = getNearestPeriod(entry, currentPeriod, currentVariation)
 		const hash = formatHash(entry.id, nearestPeriod, nearestPeriod, nearestVariation, false, false, false)
 		linkElement.href = hash
 		linkElement.addEventListener('click', e => {
 			e.preventDefault()
 			location.hash = hash
-			window.dispatchEvent(new HashChangeEvent("hashchange"))
+			// window.dispatchEvent(new HashChangeEvent("hashchange"))
 		})
-
+	
 	} else {
 		const hash = formatHash(entry.id, null, null, null, false, false, false)
 		linkElement.href = hash

--- a/web/_js/main/infoblock.js
+++ b/web/_js/main/infoblock.js
@@ -188,7 +188,7 @@ function createInfoBlock(entry, mode = 0) {
 		const editElement = document.createElement("a")
 		editElement.innerHTML = '<i class="bi bi-pencil-fill" aria-hidden="true"></i> Edit'
 		editElement.className = "btn btn-sm btn-outline-primary"
-		editElement.href = "./?mode=draw&id=" + entry.id + formatHash(false)
+		editElement.href = "./?mode=draw&id=" + entry.id + formatHash(false, null, null, null, false, false, false)
 		editElement.title = "Edit " + entry.name
 		idElementContainer.appendChild(editElement)
 	}

--- a/web/_js/main/infoblock.js
+++ b/web/_js/main/infoblock.js
@@ -31,7 +31,10 @@ function createInfoListItem(name, value) {
 	return entryInfoListElement
 }
 
-function createInfoBlock(entry, isPreview) {
+// mode 0 = normal
+// mode 1 = preview
+// mode 2 = entry list but none on atlas
+function createInfoBlock(entry, mode = 0) {
 	const element = document.createElement("div")
 	element.className = "card mb-2 overflow-hidden shadow"
 
@@ -40,12 +43,23 @@ function createInfoBlock(entry, isPreview) {
 
 	const linkElement = document.createElement("a")
 	linkElement.className = "text-decoration-none d-flex justify-content-between text-body"
-	if (isPreview) linkElement.href = "#"
-	else {
-		linkElement.href = formatHash(entry.id, null, null, null, false, false, false)
+	if (mode === 1) linkElement.href = "#"
+	else if (mode === 2) {
+		const [nearestPeriod, nearestVariation] = getNearestPeriod(entry, currentPeriod, currentVariation)
+		const hash = formatHash(entry.id, nearestPeriod, nearestPeriod, nearestVariation, false, false, false)
+		linkElement.href = hash
 		linkElement.addEventListener('click', e => {
 			e.preventDefault()
-			location.hash = formatHash(entry.id, null, null, null, false, false, false)
+			location.hash = hash
+			window.dispatchEvent(new HashChangeEvent("hashchange"))
+		})
+
+	} else {
+		const hash = formatHash(entry.id, null, null, null, false, false, false)
+		linkElement.href = hash
+		linkElement.addEventListener('click', e => {
+			e.preventDefault()
+			location.hash = hash
 			window.dispatchEvent(new HashChangeEvent("hashchange"))
 		})
 	}
@@ -92,7 +106,7 @@ function createInfoBlock(entry, isPreview) {
 	}
 
 	// Entry data submitted to preview does not include center or path
-	if (!isPreview) {
+	if (mode === 0) {
 		const [x, y] = entry?.center
 		listElement.appendChild(createInfoListItem("Position: ", `${Math.floor(x)}, ${Math.floor(y)}`))
 
@@ -170,7 +184,7 @@ function createInfoBlock(entry, isPreview) {
 	element.appendChild(idElementContainer)
 
 	// Adds edit button only if element is not deleted
-	if (!isPreview && (!entry.diff || entry.diff !== "delete")) {
+	if (mode === 0 && (!entry.diff || entry.diff !== "delete")) {
 		const editElement = document.createElement("a")
 		editElement.innerHTML = '<i class="bi bi-pencil-fill" aria-hidden="true"></i> Edit'
 		editElement.className = "btn btn-sm btn-outline-primary"

--- a/web/_js/main/main.js
+++ b/web/_js/main/main.js
@@ -105,8 +105,7 @@ async function init() {
 	// For Reviewing Reddit Changes
 	// const atlasRef = '../tools/temp-atlas.json'
 	const atlasAllUrl = params.get('atlas') || './atlas.json'
-	const atlasAllResp = await fetch(atlasAllUrl)
-	atlasAll = generateAtlasAll(await atlasAllResp.json())
+	atlasAll = generateAtlasAll(await (await fetch(atlasAllUrl)).json())
 	// console.log(atlas, atlasOrder)
 
 	const hash = window.location.hash.substring(1)
@@ -147,10 +146,8 @@ async function init() {
 		initExplore()
 	} else if (mode.startsWith("diff")) {
 		try {
-			const liveAtlasRef = params.get('liveatlas') || `https://${prodDomain}/atlas.json`
-			const liveAtlasResp = await fetch(liveAtlasRef)
-			let liveAtlasAll = await liveAtlasResp.json()
-			liveAtlasAll = generateAtlasAll(liveAtlasAll)
+			const liveAtlasUrl = params.get('liveatlas') || `https://${prodDomain}/atlas.json`
+			let liveAtlasAll = generateAtlasAll(await (await fetch(liveAtlasUrl)).json())
 
 			// Mark added/edited entries
 			for (const entry of Object.values(atlasAll)) {

--- a/web/_js/main/main.js
+++ b/web/_js/main/main.js
@@ -236,7 +236,7 @@ async function init() {
 		zoom = 1
 		zoomOrigin = [0, 0]
 		scaleZoomOrigin = [0, 0]
-		updateLines()
+		renderLines()
 		applyView()
 	})
 
@@ -365,7 +365,7 @@ async function init() {
 	}
 
 	window.addEventListener("mousemove", e => {
-		// updateLines()
+		// renderLines()
 		mousemove(e.clientX, e.clientY)
 		if (dragging) {
 			e.preventDefault()
@@ -398,7 +398,7 @@ async function init() {
 		scaleZoomOrigin[0] += deltaX / zoom
 		scaleZoomOrigin[1] += deltaY / zoom
 
-		updateLines()
+		renderLines()
 		applyView()
 	}
 
@@ -441,7 +441,7 @@ async function init() {
 		zoomOrigin[1] = scaleZoomOrigin[1] * zoom
 
 		applyView()
-		updateLines()
+		renderLines()
 	}
 
 	window.addEventListener("mouseup", e => {
@@ -467,7 +467,7 @@ async function init() {
 	function touchend(e) {
 		if (e.touches.length === 0) {
 			mouseup()
-			setTimeout(() => updateLines(), 0)
+			renderLines()
 			dragging = false
 
 		} else if (e.touches.length === 1) {

--- a/web/_js/main/main.js
+++ b/web/_js/main/main.js
@@ -149,16 +149,24 @@ async function init() {
 		try {
 			const liveAtlasRef = params.get('liveatlas') || `https://${prodDomain}/atlas.json`
 			const liveAtlasResp = await fetch(liveAtlasRef)
-			let liveAtlas = await liveAtlasResp.json()
-			liveAtlas = generateAtlasAll(liveAtlas)
+			let liveAtlasAll = await liveAtlasResp.json()
+			liveAtlasAll = generateAtlasAll(liveAtlasAll)
 
 			// Mark added/edited entries
 			for (const entry of Object.values(atlasAll)) {
-				if (!liveAtlas[entry.id]) {
+				if (!liveAtlasAll[entry.id]) {
 					entry.diff = "add"
 				} else {
-					if (JSON.stringify({ ...entry, _index: undefined }) === JSON.stringify({ ...liveAtlas[entry.id], _index: undefined })) continue
+					if (JSON.stringify({ ...entry, _index: undefined }) === JSON.stringify({ ...liveAtlasAll[entry.id], _index: undefined })) continue
 					entry.diff = "edit"
+				}
+			}
+
+			// Mark removed entries
+			for (const entry of Object.values(liveAtlasAll)) {
+				if (!atlasAll[entry.id]) {
+					entry.diff = "delete"
+					atlasAll[entry.id] = entry
 				}
 			}
 

--- a/web/_js/main/main.js
+++ b/web/_js/main/main.js
@@ -162,8 +162,6 @@ async function init() {
 				}
 			}
 
-			console.log(mode.includes('only'))
-
 			if (mode.includes('only')) {
 				for (const key of Object.keys(atlasAll)) {
 					if (atlasAll[key].diff) continue 

--- a/web/_js/main/overlap.js
+++ b/web/_js/main/overlap.js
@@ -9,21 +9,15 @@ function initOverlap() {
 
 	window.renderBackground = renderBackground
 
+	updateAtlas()
+
 	// const hovered = []
 
-	resetEntriesList()
-	renderBackground(atlas)
-	render()
-
 	document.addEventListener('timeupdate', () => {
-		atlasDisplay = atlas.slice()
-		resetEntriesList()
-		renderBackground(atlasDisplay)
-		render()
+		updateAtlas()
 	})
 
 	applyView()
-	render()
 	updateLines()
 
 	if (window.location.hash) {
@@ -37,7 +31,7 @@ function initOverlap() {
 		backgroundContext.fillStyle = "rgba(255, 255, 255, 1)"
 		backgroundContext.fillRect(0, 0, highlightCanvas.width, highlightCanvas.height)
 
-		for (const entry of atlas) {
+		for (const entry of Object.values(atlas)) {
 
 			const path = entry.path
 

--- a/web/_js/main/overlap.js
+++ b/web/_js/main/overlap.js
@@ -18,7 +18,7 @@ function initOverlap() {
 	})
 
 	applyView()
-	updateLines()
+	renderLines()
 
 	if (window.location.hash) {
 		updateViewFromHash()

--- a/web/_js/main/time.js
+++ b/web/_js/main/time.js
@@ -73,7 +73,7 @@ const dispatchTimeUpdateEvent = (period = currentPeriod, variation = currentVari
 		detail: {
 			period: period,
 			variation: variation,
-			periodString: formatPeriod(period, period, variation),
+			periodString: formatPeriod(period, null, variation),
 			atlas: atlas
 		}
 	})
@@ -278,13 +278,13 @@ function parsePeriod(periodString) {
 
 function formatPeriod(targetStart, targetEnd, targetVariation, forUrl = false) {
 	targetStart ??= currentPeriod
-	targetEnd ??= currentPeriod
+	targetEnd ??= undefined
 	targetVariation ??= currentVariation
 
 	let periodString, variationString
 	variationString = variationsConfig[targetVariation].code
 	if (targetStart > targetEnd) [targetStart, targetEnd] = [targetEnd, targetStart]
-	if (targetStart === targetEnd) {
+	if (targetStart === targetEnd || (targetStart && !targetEnd)) {
 		if (forUrl && targetVariation === defaultVariation && targetStart === variationsConfig[defaultVariation].default) {
 			periodString = ""
 		}
@@ -302,12 +302,11 @@ function setReferenceVal(reference, newValue) {
 	else return reference ?? newValue
 }
 
-function formatHash(targetEntry, targetPeriodStart, targetPeriodEnd, targetVariation, targetX, targetY, targetZoom) {
+function formatHash(targetEntry, targetPeriod, targetVariation, targetX, targetY, targetZoom) {
 	let hashData = window.location.hash.substring(1).split('/')
 
 	targetEntry = setReferenceVal(targetEntry, hashData[0])
-	targetPeriodStart = setReferenceVal(targetPeriodStart, currentPeriod)
-	targetPeriodEnd = setReferenceVal(targetPeriodEnd, currentPeriod)
+	targetPeriod = setReferenceVal(targetPeriod, currentPeriod)
 	targetVariation = setReferenceVal(targetVariation, currentVariation)
 	targetX = setReferenceVal(targetX, -scaleZoomOrigin[0])
 	targetY = setReferenceVal(targetY, -scaleZoomOrigin[1])
@@ -318,8 +317,8 @@ function formatHash(targetEntry, targetPeriodStart, targetPeriodEnd, targetVaria
 	if (targetZoom) targetZoom = targetZoom.toFixed(3).replace(/\.?0+$/, '')
 
 	const result = [targetEntry]
-	const targetPeriod = formatPeriod(targetPeriodStart, targetPeriodEnd, targetVariation, true)
-	result.push(targetPeriod, targetX, targetY, targetZoom)
+	const targetPeriodFormat = formatPeriod(targetPeriod, null, targetVariation, true)
+	result.push(targetPeriodFormat, targetX, targetY, targetZoom)
 	if (!result.some(el => el || el === 0)) return ''
 	return '#' + result.join('/').replace(/\/+$/, '')
 }

--- a/web/_js/main/time.js
+++ b/web/_js/main/time.js
@@ -336,19 +336,20 @@ function downloadCanvas() {
 
 function getNearestPeriod(entry, targetPeriod, targetVariation) {
 	
-	const entryPathPeriods = Object.keys(entry.path)
+	const pathKeys = Object.keys(entry.path)
 	
-	let nearestScore, nearestPeriod, nearestVariation
+	let nearestScore, nearestPeriod, nearestVariation, nearestKey
 
-	function updateNearest(newScore, newPeriod, newVariation) {
+	function updateNearest(newScore, newPeriod, newVariation, newKey) {
 		if (newScore >= nearestScore) return
 		nearestScore = newScore
 		nearestPeriod = newPeriod
 		nearestVariation = newVariation
+		nearestKey = newKey
 	}
 
-	checkEntryPathPeriod: for (const entryPathPeriod of entryPathPeriods) {
-		const pathPeriods = entryPathPeriod.split(', ')
+	checkEntryPathPeriod: for (const pathKey of pathKeys) {
+		const pathPeriods = pathKey.split(', ')
 
 		for (const j in pathPeriods) {
 			const [pathStart, pathEnd, pathVariation] = parsePeriod(pathPeriods[j])
@@ -356,13 +357,13 @@ function getNearestPeriod(entry, targetPeriod, targetVariation) {
 				updateNearest(0, targetPeriod, targetVariation)
 			} else {
 				if (pathVariation !== targetVariation) {
-					updateNearest(Infinity, pathStart, pathVariation)
+					updateNearest(Infinity, pathStart, pathVariation, pathKey)
 					break checkEntryPathPeriod
 				} else {
 					if (Math.abs(pathStart - targetPeriod) < Math.abs(pathEnd - targetPeriod)) {
-						updateNearest(Math.abs(pathStart - targetPeriod), pathStart, pathVariation)
+						updateNearest(Math.abs(pathStart - targetPeriod), pathStart, pathVariation, pathKey)
 					} else {
-						updateNearest(Math.abs(pathEnd - targetPeriod), pathStart, pathVariation)
+						updateNearest(Math.abs(pathEnd - targetPeriod), pathStart, pathVariation, pathKey)
 					}
 				}
 			}
@@ -370,6 +371,6 @@ function getNearestPeriod(entry, targetPeriod, targetVariation) {
 
 	}
 
-	return [ nearestPeriod, nearestVariation ]
+	return [ nearestPeriod, nearestVariation, nearestKey ]
 
 }

--- a/web/_js/main/view.js
+++ b/web/_js/main/view.js
@@ -453,7 +453,7 @@ async function resetEntriesList() {
 				})	
 			} else {
 				let entry = atlas[atlasOrder[entriesOffset]]
-				element = createInfoBlock(entry, 2)
+				element = createInfoBlock(entry, 1)
 
 				element.addEventListener("click", async e => {
 					e.preventDefault()
@@ -468,7 +468,7 @@ async function resetEntriesList() {
 					previousScaleZoomOrigin = undefined
 					previousZoom = undefined
 
-					const hash = formatHash(entry.id, nearestPeriod, nearestPeriod, nearestVariation, entry.center[0], entry.center[1], calculateZoomFromPath(entry.path))
+					const hash = formatHash(entry.id, nearestPeriod, nearestVariation, entry.center[0], entry.center[1], calculateZoomFromPath(entry.path))
 					location.hash = hash
 				})
 			}
@@ -831,6 +831,6 @@ function initViewGlobal() {
 	}
 
 	document.addEventListener('timeupdate', event => {
-		drawButton.href = "./?mode=draw" + formatHash(null, event.detail.period, event.detail.period, event.detail.variation)
+		drawButton.href = "./?mode=draw" + formatHash(null, event.detail.period, event.detail.variation)
 	})
 }

--- a/web/_js/main/view.js
+++ b/web/_js/main/view.js
@@ -158,7 +158,7 @@ function clearObjectsList() {
 function toggleFixed(e, tapped) {
 	if (!fixed && hovered.length === 0) {
 		entriesList.classList.remove("disableHover")
-		return 0
+		return
 	}
 	fixed = !fixed
 	if (!fixed) {
@@ -393,9 +393,10 @@ function updateAtlas() {
 	renderHighlight(atlasDisplay)
 }
 
-function buildObjectsList() {
-
-	let i = 0
+async function resetEntriesList() {
+	entriesOffset = 0
+	entriesList.replaceChildren()
+	entriesList.appendChild(moreEntriesButton)
 
 	moreEntriesButton.removeEventListener('click', showMoreEntries)
 	showMoreEntries = () => {
@@ -407,12 +408,12 @@ function buildObjectsList() {
 		let entriesLeft = entriesLimit
 		let element
 
-		while (entriesLeft > 0 && atlasOrder.length > i) {
+		while (entriesLeft > 0 && atlasOrder.length > entriesOffset) {
 
-			if (atlasDisplay[atlasOrder[i]]) {
+			if (atlasDisplay[atlasOrder[entriesOffset]]) {
 				// console.log(i, entriesLeft)
 	
-				let entry = atlasDisplay[atlasOrder[i]]
+				let entry = atlasDisplay[atlasOrder[entriesOffset]]
 				element = createInfoBlock(entry)
 		
 				element.addEventListener("mouseenter", function () {
@@ -451,7 +452,7 @@ function buildObjectsList() {
 					renderHighlight()
 				})	
 			} else {
-				let entry = atlas[atlasOrder[i]]
+				let entry = atlas[atlasOrder[entriesOffset]]
 				element = createInfoBlock(entry, 2)
 
 				element.addEventListener("click", async e => {
@@ -472,40 +473,21 @@ function buildObjectsList() {
 				})
 			}
 
-			i += 1
+			entriesOffset += 1
 			entriesLeft -= 1
 	
 			entriesList.appendChild(element)
 	
 		}
 	
-		if (atlasOrder.length > i) {
-			moreEntriesButton.innerHTML = "Show " + Math.min(entriesLimit, atlasOrder.length - i) + " more"
+		if (atlasOrder.length > entriesOffset) {
+			moreEntriesButton.innerHTML = "Show " + Math.min(entriesLimit, atlasOrder.length - entriesOffset) + " more"
 			entriesList.appendChild(moreEntriesButton)
 		}
 	
 	}
 	moreEntriesButton.addEventListener('click', showMoreEntries)
 	showMoreEntries()
-
-}
-
-function shuffle() {
-	//console.log("shuffled atlas")
-	for (let i = atlasDisplay.length - 1; i > 0; i--) {
-		const j = Math.floor(Math.random() * (i + 1))
-		const temp = atlasDisplay[i]
-		atlasDisplay[i] = atlasDisplay[j]
-		atlasDisplay[j] = temp
-	}
-}
-
-async function resetEntriesList() {
-	entriesOffset = 0
-	entriesList.replaceChildren()
-	entriesList.appendChild(moreEntriesButton)
-
-	buildObjectsList()
 }
 
 async function renderHighlight() {

--- a/web/_js/main/view.js
+++ b/web/_js/main/view.js
@@ -455,6 +455,7 @@ function buildObjectsList() {
 				element = createInfoBlock(entry, 2)
 
 				element.addEventListener("click", async e => {
+					e.preventDefault()
 					const [nearestPeriod, nearestVariation] = getNearestPeriod(entry, currentPeriod, currentVariation)
 
 					await updateTime(nearestPeriod, nearestVariation, true)
@@ -465,13 +466,9 @@ function buildObjectsList() {
 					fixed = true
 					previousScaleZoomOrigin = undefined
 					previousZoom = undefined
-					
-					renderHighlight()
-					window.dispatchEvent(new HashChangeEvent("hashchange"))
 
-					setView(entry.center[0], entry.center[1], calculateZoomFromPath(entry.path))
-					updateLines()
-
+					const hash = formatHash(entry.id, nearestPeriod, nearestPeriod, nearestVariation, entry.center[0], entry.center[1], calculateZoomFromPath(entry.path))
+					location.hash = hash
 				})
 			}
 
@@ -669,7 +666,7 @@ function updateHovering(e, tapped) {
 
 window.addEventListener("hashchange", updateViewFromHash)
 
-function updateViewFromHash() {
+async function updateViewFromHash() {
 
 	const hash = window.location.hash.substring(1); //Remove hash prefix
 	let [hashEntryId, hashPeriod, hashX, hashY, hashZoom] = hash.split('/')
@@ -691,7 +688,7 @@ function updateViewFromHash() {
 		targetPeriod = defaultPeriod
 		targetVariation = defaultVariation
 	}
-	updateTime(targetPeriod, targetVariation, true)
+	await updateTime(targetPeriod, targetVariation)
 
 	setView(
 		isNaN(hashX) ? scaleZoomOrigin[0] : Number(hashX), 
@@ -722,7 +719,6 @@ function updateViewFromHash() {
 	objectsContainer.replaceChildren()
 	objectsContainer.appendChild(infoElement)
 
-	renderBackground(atlas)
 	setView(
 		isNaN(hashX) ? entry.center[0] : Number(hashX), 
 		isNaN(hashY) ? entry.center[1] : Number(hashY), 
@@ -733,7 +729,8 @@ function updateViewFromHash() {
 	entriesList.classList.add("disableHover")
 
 	hovered = [{...entry, element: infoElement}]
-	renderHighlight()
+	renderBackground(atlasDisplay)
+	renderHighlight(atlasDisplay)
 	updateLines()
 }
 

--- a/web/_js/main/view.js
+++ b/web/_js/main/view.js
@@ -535,28 +535,6 @@ async function renderHighlight() {
 	highlightContext.globalCompositeOperation = "source-out"
 	highlightContext.drawImage(backgroundCanvas, 0, 0)
 
-	// if (hovered.length === 1 && hovered[0].path.length && hovered[0].overrideImage) {
-	// 	const undisputableHovered = hovered[0]
-	// 	// Find the left-topmost point of all the paths
-	// 	const entryPosition = getPositionOfEntry(undisputableHovered)
-	// 	if (entryPosition) {
-	// 		const [startX, startY] = entryPosition
-	// 		const overrideImage = new Image()
-	// 		const loadingPromise = new Promise((res, rej) => {
-	// 			overrideImage.onerror = rej
-	// 			overrideImage.onload = res
-	// 		})
-	// 		overrideImage.src = "imageOverrides/" + undisputableHovered.overrideImage
-	// 		try {
-	// 			await loadingPromise
-	// 			highlightContext.globalCompositeOperation = "source-over"
-	// 			highlightContext.drawImage(overrideImage, startX, startY)
-	// 		} catch (ex) {
-	// 			console.error("Cannot override image.", ex)
-	// 		}
-	// 	}
-	// }
-
 	for (let i = 0; i < hovered.length; i++) {
 
 		const path = hovered[i].path

--- a/web/_js/main/view.js
+++ b/web/_js/main/view.js
@@ -685,7 +685,6 @@ function updateViewFromHash() {
 	// Highlight entry from hash
 
 	const entry = atlasDisplay[hashEntryId]
-	console.log(entry)
 	if (!entry) return 
 		
 	document.title = entry.name + " on " + pageTitle

--- a/web/_js/main/view.js
+++ b/web/_js/main/view.js
@@ -117,7 +117,7 @@ offcanvasList.addEventListener('shown.bs.offcanvas', e => {
 	updateHovering(e)
 	applyView()
 	renderHighlight()
-	updateLines()
+	renderLines()
 })
 
 offcanvasList.addEventListener('hide.bs.offcanvas', () => {
@@ -132,7 +132,7 @@ offcanvasList.addEventListener('hidden.bs.offcanvas', e => {
 	updateHovering(e)
 	applyView()
 	renderHighlight()
-	updateLines()
+	renderLines()
 })
 
 closeObjectsListButton.addEventListener("click", clearObjectsList)
@@ -142,17 +142,17 @@ bottomBar.addEventListener("mouseover", () => {
 })
 
 function clearObjectsList() {
+	renderLines()
+	renderHighlight()
+	hovered = []
+	fixed = false
+	document.title = pageTitle
 	closeObjectsListButton.classList.add("d-none")
 	objectsListOverflowNotice.classList.add("d-none")
 	entriesList.classList.remove("disableHover")
-	hovered = []
 	objectsContainer.replaceChildren()
-	updateLines()
-	fixed = false
-	renderHighlight()
 	objectEditNav.remove()
 	updateHash(false)
-	document.title = pageTitle
 }
 
 function toggleFixed(e, tapped) {
@@ -169,24 +169,24 @@ function toggleFixed(e, tapped) {
 	objectsListOverflowNotice.classList.add("d-none")
 }
 
-window.addEventListener("resize", updateLines)
-window.addEventListener("mousemove", updateLines)
-window.addEventListener("dblClick", updateLines)
-window.addEventListener("wheel", updateLines)
+window.addEventListener("resize", renderLines)
+window.addEventListener("mousemove", renderLines)
+window.addEventListener("dblClick", renderLines)
+window.addEventListener("wheel", renderLines)
 
 objectsContainer.addEventListener("scroll", () => {
-	updateLines()
+	renderLines()
 })
 
 window.addEventListener("resize", () => {
 
 	applyView()
 	renderHighlight()
-	updateLines()
+	renderLines()
 
 })
 
-function updateLines() {
+async function renderLines() {
 
 	// Line border
 	linesCanvas.width = linesCanvas.clientWidth
@@ -426,7 +426,7 @@ function buildObjectsList() {
 					hovered = [entry]
 					renderHighlight()
 					hovered[0].element = this
-					updateLines()
+					renderLines()
 					
 				})
 		
@@ -447,7 +447,7 @@ function buildObjectsList() {
 					applyView()
 		
 					hovered = []
-					updateLines()
+					renderLines()
 					renderHighlight()
 				})	
 			} else {
@@ -731,7 +731,7 @@ async function updateViewFromHash() {
 	hovered = [{...entry, element: infoElement}]
 	renderBackground(atlasDisplay)
 	renderHighlight(atlasDisplay)
-	updateLines()
+	renderLines()
 }
 
 function calculateZoomFromPath(path) {
@@ -772,7 +772,7 @@ function initView() {
 	}*/
 
 	applyView()
-	updateLines()
+	renderLines()
 
 }
 


### PR DESCRIPTION
This PR changes the architecture from the old period-first way (atlas data filtered by period, then filtered with search parameters and sort order), to filter-first way (atlas data filtered with search params and sorted first, then filtered by period). 

This should give way for more streamlined approach in code (last time, it was so intertwined/in a roundabout way), as well as to show all atlas data on the search without regarding the timeline period.

Refactors are also included. Further testing is required.