### PR TITLE
Edit the entry for the PKP intercity train

### DIFF
--- a/data/patches/gh-64f5-ed250-pendolino-pkp-intercity-train.json
+++ b/data/patches/gh-64f5-ed250-pendolino-pkp-intercity-train.json
@@ -1,0 +1,41 @@
+{
+	"id": 1223,
+	"name": "ED250 Pendolino PKP Intercity Train",
+	"description": "Express InterCity Premium (EIP), often simply called \"Pendolino\", which is the name of the Italian trains used, is a high-speed train system operating in Poland operated by PKP (\"Polskie Koleje Państwowe\" - \"Polish State Railways\"). The trains are designed for operation at up to 250 km/h (with 293 km/h reached under controlled conditions). However, they only reach 200 km/h during regular service.",
+	"links": {
+		"website": [
+			"https://en.wikipedia.org/wiki/Pendolino",
+			"https://en.wikipedia.org/wiki/Polish_State_Railways"
+		],
+		"subreddit": [
+			"Polska",
+			"poland"
+		]
+	},
+	"path": {
+		"139-258": [
+			[
+				757,
+				-114
+			],
+			[
+				735,
+				-128
+			],
+			[
+				682,
+				-128
+			],
+			[
+				682,
+				-114
+			]
+		]
+	},
+	"center": {
+		"139-258": [
+			717,
+			-121
+		]
+	}
+}


### PR DESCRIPTION
Edit to fix the service being incorrectly called EIC, as well as to add more information.