### PR TITLE
Add the Printful entry (gh-fd46-printful.json)

### DIFF
--- a/data/patches/gh-fd46-printful.json
+++ b/data/patches/gh-fd46-printful.json
@@ -1,0 +1,43 @@
+{
+	"id": -1,
+	"name": "Printful",
+	"description": "Printful is a Latvian company that provides on-demand printing and dropshipping services.\n\nThey offer a wide range of customizable products, such as apparel, accessories, and home goods, allowing businesses to create and sell their own branded merchandise without the need for inventory management or upfront costs.",
+	"links": {
+		"website": [
+			"https://www.printful.com/"
+		],
+		"subreddit": [
+			"printful"
+		]
+	},
+	"path": {
+		"250": [
+			[
+				-31,
+				566
+			],
+			[
+				-3,
+				566
+			],
+			[
+				-3,
+				585
+			],
+			[
+				-31,
+				585
+			],
+			[
+				-31,
+				585
+			]
+		]
+	},
+	"center": {
+		"250": [
+			-17,
+			576
+		]
+	}
+}


### PR DESCRIPTION
Added the Printful logo to the atlas (gh-fd46-printful.json).

Logo itself is below the Latvian TV tower, aka from (-31, 566) to (-3, 585)