### PR TITLE
Create gh-9afd-danke-kenteken.json

### DIFF
--- a/data/patches/gh-9afd-danke-kenteken.json
+++ b/data/patches/gh-9afd-danke-kenteken.json
@@ -1,0 +1,40 @@
+{
+	"id": 847,
+	"name": "Danke Kenteken",
+	"description": "This is a Dutch license plate to prove the cooperation between Germany and the Netherlands and to thank them for protecting our area. The numbers are supposed to be 49, Germany's land code. Officially Dutch license plates are not allowed to have vowels.",
+	"links": {
+		"website": [
+			"https://en.wikipedia.org/wiki/Vehicle_registration_plates_of_the_Netherlands"
+		],
+		"subreddit": [
+			"PlaceNL",
+			"placeDE"
+		]
+	},
+	"path": {
+		"64-256": [
+			[
+				606,
+				-462
+			],
+			[
+				606,
+				-452
+			],
+			[
+				649,
+				-452
+			],
+			[
+				649,
+				-462
+			]
+		]
+	},
+	"center": {
+		"64-256": [
+			628,
+			-457
+		]
+	}
+}


### PR DESCRIPTION
Add info on that the numbers are supposed to be 49, and that vowels are officially not allowed on Dutch license plates.