### PR TITLE
Edit Snorlax & Friends (id: 2924)

### DIFF
--- a/data/patches/gh-97b0-snorlax-friends.json
+++ b/data/patches/gh-97b0-snorlax-friends.json
@@ -1,0 +1,48 @@
+{
+	"id": 2924,
+  "_author": "Champi0n1"
+	"name": "Snorlax & Friends",
+	"description": "A Pokemon named Snorlax joined by a Shiny Goomy and Babousa the green slug from the streamer AgenteMaxo and assisted by the streamer Chainavt to battle off the void!",
+	"links": {
+		"subreddit": [
+			"placepokemon2"
+		],
+		"discord": [
+			"TZeRPaFZ"
+		]
+	},
+	"path": {
+		"202-256": [
+			[
+				1082,
+				250
+			],
+			[
+				1054,
+				250
+			],
+			[
+				1054,
+				257
+			],
+			[
+				1049,
+				257
+			],
+			[
+				1049,
+				281
+			],
+			[
+				1082,
+				281
+			]
+		]
+	},
+	"center": {
+		"202-256": [
+			1067,
+			266
+		]
+	}
+}


### PR DESCRIPTION
Upon member request, adding information about alliance and battling off the many attacks from the void.

Additionally adding in optional author information.