### PR TITLE
Update dependencies, add "staging merge" label automation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,15 @@
 'atlas data: patch':
+- changed-files:
   - data/patches/**
 
 'atlas data: direct':
+- changed-files:
   - web/atlas.json
+
+staging merge:
+- all:
+  - base-branch:
+    - master
+  - head-branch:
+    - cleanup
+    - staging/'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -10,4 +10,4 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v4
+    - uses: actions/labeler@v5

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -28,7 +28,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Check using Qodana

--- a/.github/workflows/validate-json.yml
+++ b/.github/workflows/validate-json.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('tools/ci/requirements.txt') }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "place-atlas-2023",
 			"devDependencies": {
 				"@fullhuman/postcss-purgecss": "^5.0.0",
 				"@parcel/packager-raw-url": "^2.8.3",
@@ -559,15 +560,6 @@
 				"node": ">=0.8"
 			}
 		},
-		"node_modules/@parcel/core/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
 		"node_modules/@parcel/diagnostic": {
 			"version": "2.8.3",
 			"resolved": "https://registry.npmjs.org/@parcel/diagnostic/-/diagnostic-2.8.3.tgz",
@@ -811,15 +803,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/node-resolver-core/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
 		"node_modules/@parcel/optimizer-css": {
 			"version": "2.8.3",
 			"resolved": "https://registry.npmjs.org/@parcel/optimizer-css/-/optimizer-css-2.8.3.tgz",
@@ -997,15 +980,6 @@
 			},
 			"peerDependencies": {
 				"@parcel/core": "^2.8.3"
-			}
-		},
-		"node_modules/@parcel/package-manager/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
 			}
 		},
 		"node_modules/@parcel/packager-css": {
@@ -1409,15 +1383,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/transformer-babel/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
 		"node_modules/@parcel/transformer-css": {
 			"version": "2.8.3",
 			"resolved": "https://registry.npmjs.org/@parcel/transformer-css/-/transformer-css-2.8.3.tgz",
@@ -1464,15 +1429,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-html/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
 			}
 		},
 		"node_modules/@parcel/transformer-image": {
@@ -1522,15 +1478,6 @@
 			},
 			"peerDependencies": {
 				"@parcel/core": "^2.8.3"
-			}
-		},
-		"node_modules/@parcel/transformer-js/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
 			}
 		},
 		"node_modules/@parcel/transformer-json": {
@@ -1603,15 +1550,6 @@
 				"node": ">=0.8"
 			}
 		},
-		"node_modules/@parcel/transformer-postcss/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
 		"node_modules/@parcel/transformer-posthtml": {
 			"version": "2.8.3",
 			"resolved": "https://registry.npmjs.org/@parcel/transformer-posthtml/-/transformer-posthtml-2.8.3.tgz",
@@ -1633,15 +1571,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-posthtml/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
 			}
 		},
 		"node_modules/@parcel/transformer-raw": {
@@ -1702,15 +1631,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/transformer-svg/node_modules/semver": {
-			"version": "5.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
 			}
 		},
 		"node_modules/@parcel/transformer-webmanifest": {
@@ -3710,12 +3630,12 @@
 			}
 		},
 		"node_modules/msgpackr": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.5.tgz",
-			"integrity": "sha512-mpPs3qqTug6ahbblkThoUY2DQdNXcm4IapwOS3Vm/87vmpzLVelvp9h3It1y9l1VPpiFLV11vfOXnmeEwiIXwg==",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.1.tgz",
+			"integrity": "sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==",
 			"dev": true,
 			"optionalDependencies": {
-				"msgpackr-extract": "^3.0.1"
+				"msgpackr-extract": "^3.0.2"
 			}
 		},
 		"node_modules/msgpackr-extract": {
@@ -3759,10 +3679,16 @@
 			"dev": true
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
 			},
@@ -4128,9 +4054,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.21",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-			"integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+			"version": "8.4.35",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+			"integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
 			"dev": true,
 			"funding": [
 				{
@@ -4140,10 +4066,14 @@
 				{
 					"type": "tidelift",
 					"url": "https://tidelift.com/funding/github/npm/postcss"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
 				}
 			],
 			"dependencies": {
-				"nanoid": "^3.3.4",
+				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			},
@@ -4799,6 +4729,15 @@
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true
+		},
+		"node_modules/semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+			"dev": true,
+			"bin": {
+				"semver": "bin/semver"
+			}
 		},
 		"node_modules/set-blocking": {
 			"version": "2.0.0",
@@ -5643,12 +5582,6 @@
 					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
 					"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
 					"dev": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
 				}
 			}
 		},
@@ -5800,14 +5733,6 @@
 				"@parcel/utils": "2.8.3",
 				"nullthrows": "^1.1.1",
 				"semver": "^5.7.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"@parcel/optimizer-css": {
@@ -5903,14 +5828,6 @@
 				"@parcel/utils": "2.8.3",
 				"@parcel/workers": "2.8.3",
 				"semver": "^5.7.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"@parcel/packager-css": {
@@ -6161,14 +6078,6 @@
 				"json5": "^2.2.0",
 				"nullthrows": "^1.1.1",
 				"semver": "^5.7.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"@parcel/transformer-css": {
@@ -6201,14 +6110,6 @@
 				"posthtml-render": "^3.0.0",
 				"semver": "^5.7.1",
 				"srcset": "4"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"@parcel/transformer-image": {
@@ -6240,14 +6141,6 @@
 				"nullthrows": "^1.1.1",
 				"regenerator-runtime": "^0.13.7",
 				"semver": "^5.7.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"@parcel/transformer-json": {
@@ -6292,12 +6185,6 @@
 					"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
 					"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
 					"dev": true
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
 				}
 			}
 		},
@@ -6314,14 +6201,6 @@
 				"posthtml-parser": "^0.10.1",
 				"posthtml-render": "^3.0.0",
 				"semver": "^5.7.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"@parcel/transformer-raw": {
@@ -6358,14 +6237,6 @@
 				"posthtml-parser": "^0.10.1",
 				"posthtml-render": "^3.0.0",
 				"semver": "^5.7.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				}
 			}
 		},
 		"@parcel/transformer-webmanifest": {
@@ -7783,12 +7654,12 @@
 			}
 		},
 		"msgpackr": {
-			"version": "1.8.5",
-			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.8.5.tgz",
-			"integrity": "sha512-mpPs3qqTug6ahbblkThoUY2DQdNXcm4IapwOS3Vm/87vmpzLVelvp9h3It1y9l1VPpiFLV11vfOXnmeEwiIXwg==",
+			"version": "1.10.1",
+			"resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.10.1.tgz",
+			"integrity": "sha512-r5VRLv9qouXuLiIBrLpl2d5ZvPt8svdQTl5/vMvE4nzDMyEX4sgW5yWhuBBj5UmgwOTWj8CIdSXn5sAfsHAWIQ==",
 			"dev": true,
 			"requires": {
-				"msgpackr-extract": "^3.0.1"
+				"msgpackr-extract": "^3.0.2"
 			}
 		},
 		"msgpackr-extract": {
@@ -7823,9 +7694,9 @@
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
-			"integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+			"version": "3.3.7",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+			"integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
 			"dev": true
 		},
 		"node-addon-api": {
@@ -8073,12 +7944,12 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "8.4.21",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
-			"integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
+			"version": "8.4.35",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
+			"integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
 			"dev": true,
 			"requires": {
-				"nanoid": "^3.3.4",
+				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
 				"source-map-js": "^1.0.2"
 			}
@@ -8532,6 +8403,12 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
+		},
+		"semver": {
+			"version": "5.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 			"dev": true
 		},
 		"set-blocking": {


### PR DESCRIPTION
Updating some dependencies to avoid GitHub complaining about the old Node.js version, and also you can now use branches on the `actions/labeler` workflow, so why not?