### PR TITLE
Change the button text when submitting directly

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -382,8 +382,8 @@
 				<div class="modal-footer">
 					<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Done</button>
 					<button id="exportCopy" type="button" class="btn btn-secondary">Copy</button>
-					<a id="exportGithubPost" class="btn btn-primary" href="#" target="_blank" rel="noreferrer">Submit Direct on GitHub</a>
-					<a id="exportRedditPost" class="btn btn-primary" href="#" target="_blank" rel="noreferrer">Post Direct on Reddit</a>
+					<a id="exportGithubPost" class="btn btn-primary" href="#" target="_blank" rel="noreferrer">➤ GitHub</a>
+					<a id="exportRedditPost" class="btn btn-primary" href="#" target="_blank" rel="noreferrer">➤ Reddit</a>
 				</div>
 				</div>
 			</div>


### PR DESCRIPTION
Fixes #243

Change the button text for submitting directly to GitHub and Reddit.

* Change the button text for the button with ID `exportGithubPost` to '➤ GitHub' in `web/index.html`.
* Change the button text for the button with ID `exportRedditPost` to '➤ Reddit' in `web/index.html`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/placeAtlas/atlas-2023/issues/243?shareId=XXXX-XXXX-XXXX-XXXX).